### PR TITLE
Off-by-one array index resulting in buffer overflow

### DIFF
--- a/src/common/AWSClient4.cpp
+++ b/src/common/AWSClient4.cpp
@@ -182,9 +182,9 @@ char* AWSClient4::createRequest(MinimalString &reqPayload) {
     // @TODO: find out why sprintf doesn't work
     const char* dateTime = dateTimeProvider->getDateTime();
     strncpy(awsDate, dateTime, 8);
-    awsDate[9] = '\0';
+    awsDate[AWS_DATE_LEN4] = '\0';
     strncpy(awsTime, dateTime + 8, 6);
-    awsTime[7] = '\0';
+    awsTime[AWS_TIME_LEN4] = '\0';
 
     SHA256* sha256 = new SHA256();
     payloadHash = (*sha256)(reqPayload.getCStr(), reqPayload.length());


### PR DESCRIPTION
`awsDate` is `char[9]` and `awsTime` is `char[7]`. `AWSClient4::createRequest` assigns to `awsDate[9]` and `awsTime[7]`, resulting in a buffer overflow and possible exception with debug message like "there is no poison after the block. Expected poison address:" from umm_malloc.c.

Write `'\0'` to `awsDate[8]` and `awsTime[6]` instead.